### PR TITLE
PFS-4573: fix pre-test to select eng always as language

### DIFF
--- a/Scripts/Links/pre_test/check_eng/Script1745767555044.groovy
+++ b/Scripts/Links/pre_test/check_eng/Script1745767555044.groovy
@@ -25,7 +25,7 @@ WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/My_a
 
 WebUI.click(findTestObject('My_Account/Overview/Page_Profile - PowerFolder/Change_Language'))
 
-WebUI.selectOptionByLabel(findTestObject('My_Account/Overview/Page_Profile - PowerFolder/Select Langue'), 'English', false)
+WebUI.selectOptionByValue(findTestObject('My_Account/Overview/Page_Profile - PowerFolder/Select Langue'), 'en', false)
 
 WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/Page_Profile - PowerFolder/button_Change_langue'))
 
@@ -34,3 +34,4 @@ WebUI.delay(2)
 WebUI.verifyElementText(findTestObject('My_Account/Overview/Page_Profile - PowerFolder/td_lang'), 'English')
 
 WebUI.closeBrowser()
+


### PR DESCRIPTION
This branch features:

* fix of pre-test: check_eng

The pretest is used in AllTest_Suite to set UI-language to ENG and is mandatory. 
With the addition of new languages the test failed to set the correct language - this is now fixed.

Ran successfuly on locally & on mimas with 23.3.1.