### PR TITLE
PFS-4612: adapt webtest to work on correct url-endpoint

### DIFF
--- a/Scripts/External links/Licence/TEL17_license/Script1753890230648.groovy
+++ b/Scripts/External links/Licence/TEL17_license/Script1753890230648.groovy
@@ -31,13 +31,13 @@ String currentUrl = WebUI.getUrl()
 
 WebUI.comment('L\'URL actuelle est: ' + currentUrl)
 
-String expectedUrl = 'https://mimas.powerfolder.net/pricing'
+String expectedUrl = 'https://www.powerfolder.com/pricing/'
 
 boolean isCorrectUrl = currentUrl.equals(expectedUrl)
 
 WebUI.verifyEqual(isCorrectUrl, true)
 
-WebUI.verifyElementText(findTestObject('External links/Page_Pricing - PowerFolder/license_Our Flexible Plans'), 'Our Flexible Plans')
+WebUI.verifyElementText(findTestObject('External links/Page_Pricing/Compare Functions'), 'COMPARE FUNCTIONS')
 
 WebUI.closeWindowIndex(1)
 


### PR DESCRIPTION
This branch features:

- an update of the TEL17 webtest to checkout correct url-endpoint

Ran successfully on mimas 23.4.3.