### PR TITLE
PFS-5455: create webtest which checks if cut&paste is disabled for toplvl folder

### DIFF
--- a/Object Repository/Folders/Page_Folders - PowerFolder/Cut_Folder.rs
+++ b/Object Repository/Folders/Page_Folders - PowerFolder/Cut_Folder.rs
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WebElementEntity>
+   <description></description>
+   <name>Cut_Folder</name>
+   <tag></tag>
+   <elementGuidId>dd3b994d-b7f9-4b17-8f00-ed13b3622fd8</elementGuidId>
+   <selectorCollection>
+      <entry>
+         <key>XPATH</key>
+         <value>//body/div[2]/div[1]/div[2]/div[2]/table/thead[1]/tr/th[3]/div[2]/a[4]/lang</value>
+      </entry>
+      <entry>
+         <key>BASIC</key>
+         <value></value>
+      </entry>
+   </selectorCollection>
+   <selectorMethod>XPATH</selectorMethod>
+   <smartLocatorEnabled>false</smartLocatorEnabled>
+   <useRalativeImagePath>false</useRalativeImagePath>
+</WebElementEntity>

--- a/Scripts/File/TF26_Verify NoCutPaste On TopLevelFolder/Script1776365966875.groovy
+++ b/Scripts/File/TF26_Verify NoCutPaste On TopLevelFolder/Script1776365966875.groovy
@@ -1,0 +1,117 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.annotation.Keyword as Keyword
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberBuiltinKeywords
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as MobileBuiltInKeywords
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGBuiltinKeywords
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WSBuiltInKeywords
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUiBuiltInKeywords
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as WindowsBuiltinKeywords
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+import org.apache.commons.lang3.RandomStringUtils as RandomStringUtils
+import com.kms.katalon.core.webui.driver.DriverFactory as DriverFactory
+import org.openqa.selenium.WebDriver as WebDriver
+import org.openqa.selenium.WebElement as WebElement
+import org.openqa.selenium.By as By
+import java.util.Arrays as Arrays
+import org.openqa.selenium.support.ui.ExpectedConditions as ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait as WebDriverWait
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import com.kms.katalon.core.testobject.ConditionType as ConditionType
+import com.kms.katalon.core.util.KeywordUtil as KeywordUtil
+
+String folderName_1 = getRandomFolderName()
+
+WebUiBuiltInKeywords.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+WebUiBuiltInKeywords.click(findTestObject('Object Repository/Groups/Page_Folders - PowerFolder/lang_Folders'))
+
+WebUiBuiltInKeywords.click(findTestObject('Object Repository/Folders/createFolderIcon'))
+
+WebUiBuiltInKeywords.click(findTestObject('Object Repository/Folders/createFolder'))
+
+// crete toplevel dir
+WebUiBuiltInKeywords.setText(findTestObject('Object Repository/Folders/inputFolderName'), folderName_1)
+
+WebUiBuiltInKeywords.click(findTestObject('Object Repository/Folders/buttonOK'))
+
+WebUI.click(findTestObject('Object Repository/Folders/Page_Folders - PowerFolder/lang_Folders'))
+
+WebUI.delay(2)
+
+WebElement btn = findDoc(folderName_1)
+
+WebUI.executeJavaScript('arguments[0].click()', Arrays.asList(btn))
+
+TestObject cutButton = new TestObject('cutButton')
+
+cutButton.addProperty('xpath', ConditionType.EQUALS, '//a[contains(@class,\'files-ui-cut\')]//lang[text()=\'Cut\']')
+
+// Check: the Cut button must NOT exist for a top-level folder
+boolean isPresent = WebUI.verifyElementPresent(cutButton, 3, FailureHandling.OPTIONAL)
+
+if (isPresent) {
+    KeywordUtil.markFailedAndStop('❌ The CUT button exists in a top-level folder (unexpected behavior)')
+} else {
+    KeywordUtil.markPassed('✅ Cut button is not present as expected')
+}
+
+WebUI.delay(2)
+
+WebUI.closeBrowser()
+
+@Keyword
+WebElement findFolder(String folderName) {
+    WebDriver driver = DriverFactory.getWebDriver()
+
+    return driver.findElement(By.xpath(('//td[2]/span/a[contains(text(),\'' + folderName) + '\')]'))
+}
+
+String getTimestamp() {
+    Date todaysDate = new Date()
+
+    String formattedDate = todaysDate.format('dd_MMM_yyyy_hh_mm_ss')
+
+    return formattedDate
+}
+
+String getRandomFileName() {
+    String fileName = 'File_' + getTimestamp()
+
+    return fileName
+}
+
+String getRandomFolderName() {
+    String folderName = 'Folder_' + getTimestamp()
+
+    return folderName
+}
+
+@Keyword
+WebElement findDoc(String DocName) {
+    WebDriver driver = DriverFactory.getWebDriver()
+
+    return driver.findElement(By.xpath(('//*[contains(@data-search-keys, \'' + DocName) + '\')]/td[1]/span'))
+}
+
+boolean isDocPresent(String docName) {
+    WebDriver driver = DriverFactory.getWebDriver()
+
+    List<WebElement> docs = driver.findElements(By.xpath(('//*[contains(@data-search-keys, \'' + docName) + '\')]/td[1]/span'))
+
+    return !(docs.isEmpty())
+}
+

--- a/Test Cases/File/TF26_Verify NoCutPaste On TopLevelFolder.tc
+++ b/Test Cases/File/TF26_Verify NoCutPaste On TopLevelFolder.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>TF26_Verify NoCutPaste On TopLevelFolder</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>e76b6252-fc76-47f4-bde5-6e5843ae3dae</testCaseGuid>
+</TestCaseEntity>

--- a/Test Suites/AllTest.ts
+++ b/Test Suites/AllTest.ts
@@ -2916,4 +2916,11 @@
       <testCaseId>Test Cases/File/TF25_Cut File from toplv to subdir</testCaseId>
       <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
    </testCaseLink>
+   <testCaseLink>
+      <guid>96574f02-5a86-4d90-9fff-6daf52f8f6c0</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/File/TF26_Verify NoCutPaste On TopLevelFolder</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
 </TestSuiteEntity>

--- a/Test Suites/File.ts
+++ b/Test Suites/File.ts
@@ -289,4 +289,11 @@
       <testCaseId>Test Cases/File/TF25_Cut File from toplv to subdir</testCaseId>
       <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
    </testCaseLink>
+   <testCaseLink>
+      <guid>b2d4df0d-5de5-4e86-9825-0cad8d78e77e</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/File/TF26_Verify NoCutPaste On TopLevelFolder</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
 </TestSuiteEntity>

--- a/settings/internal/com.kms.katalon.composer.testcase.properties
+++ b/settings/internal/com.kms.katalon.composer.testcase.properties
@@ -1,2 +1,2 @@
-#Wed Apr 15 20:11:16 WEST 2026
+#Sat Apr 18 11:34:17 WEST 2026
 testCaseTag=""


### PR DESCRIPTION
This branch features:

- the new testcase TF26 which checks if the cut&paste option is hidden for toplvl folders.

This branch ran succesfully on mimas with 26.2.39.