### PR TITLE
PFS-5477: create testcases which use browsers back button

### DIFF
--- a/Object Repository/Emails/Emails_lang.rs
+++ b/Object Repository/Emails/Emails_lang.rs
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WebElementEntity>
+   <description></description>
+   <name>Emails_lang</name>
+   <tag></tag>
+   <elementGuidId>5f9cda5c-8295-4e27-8bda-8e0aacf4864c</elementGuidId>
+   <selectorCollection>
+      <entry>
+         <key>BASIC</key>
+         <value></value>
+      </entry>
+      <entry>
+         <key>XPATH</key>
+         <value>//body/div[2]/div[1]/div[1]/table/tbody/tr[13]/td/a/lang</value>
+      </entry>
+   </selectorCollection>
+   <selectorMethod>XPATH</selectorMethod>
+   <smartLocatorEnabled>false</smartLocatorEnabled>
+   <useRalativeImagePath>false</useRalativeImagePath>
+</WebElementEntity>

--- a/Scripts/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard/Script1777630879263.groovy
+++ b/Scripts/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard/Script1777630879263.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> Folders
+WebUI.click(findTestObject('Dashboard/lang_Folders'))
+
+WebUI.delay(2)
+
+// Verify Folders page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Folders - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard/Script1777630879277.groovy
+++ b/Scripts/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard/Script1777630879277.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> Accounts
+WebUI.click(findTestObject('Dashboard/lang_Accounts'))
+
+WebUI.delay(2)
+
+// Verify Accounts page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Accounts - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard/Script1777630879292.groovy
+++ b/Scripts/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard/Script1777630879292.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> organizations
+WebUI.click(findTestObject('Organization/SelectOrganization'))
+
+WebUI.delay(2)
+
+// Verify Organizations page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Organizations - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard/Script1777630879301.groovy
+++ b/Scripts/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard/Script1777630879301.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> Servers
+WebUI.click(findTestObject('servers/Page_Dashboard - PowerFolder/lang_Servers_v'))
+
+WebUI.delay(2)
+
+// Verify Servers page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Servers - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard/Script1777630879309.groovy
+++ b/Scripts/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard/Script1777630879309.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> storages
+WebUI.click(findTestObject('LeftNavigationIcons/Storage'))
+
+WebUI.delay(2)
+
+// Verify storages page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Storage - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard/Script1777630879318.groovy
+++ b/Scripts/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard/Script1777630879318.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> email-preview
+WebUI.click(findTestObject('Emails/Emails_lang'))
+
+WebUI.delay(2)
+
+// Verify email-preview page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Email Preview - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard/Script1777630879328.groovy
+++ b/Scripts/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard/Script1777630879328.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> Logs
+WebUI.click(findTestObject('1Logs/Page_Dashboard - PowerFolder/lang_Logs'))
+
+WebUI.delay(2)
+
+// Verify Logs page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Logs - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard/Script1777630879339.groovy
+++ b/Scripts/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard/Script1777630879339.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> Preferences
+WebUI.click(findTestObject('LeftNavigationIcons/Preferences'))
+
+WebUI.delay(2)
+
+// Verify Preferences page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Preferences - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard/Script1777632801344.groovy
+++ b/Scripts/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard/Script1777632801344.groovy
@@ -1,0 +1,39 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testng.keyword.TestNGBuiltinKeywords as TestNGKW
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import internal.GlobalVariable as GlobalVariable
+import org.openqa.selenium.Keys as Keys
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.STOP_ON_FAILURE)
+
+// Dashboard -> News
+WebUI.click(findTestObject('News_User/Page_News - PowerFolder/News'))
+
+WebUI.delay(2)
+
+// Verify News page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'News - PowerFolder')
+
+// Browser back button
+WebUI.back()
+
+WebUI.delay(2)
+
+// Verify Dashboard page
+WebUI.verifyEqual(WebUI.getWindowTitle(), 'Dashboard - PowerFolder')
+
+WebUI.closeBrowser()
+

--- a/Scripts/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList/Script1777630879348.groovy
+++ b/Scripts/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList/Script1777630879348.groovy
@@ -1,0 +1,121 @@
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import org.openqa.selenium.By as By
+import org.openqa.selenium.JavascriptExecutor as JavascriptExecutor
+import org.openqa.selenium.Keys as Keys
+import org.openqa.selenium.WebDriver as WebDriver
+import org.openqa.selenium.WebElement as WebElement
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.webui.driver.DriverFactory as DriverFactory
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import internal.GlobalVariable as GlobalVariable
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+
+GlobalVariable.userEmail = generateRandomEmail().toLowerCase()
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.OPTIONAL)
+
+WebUI.click(findTestObject('LeftNavigationIcons/account'))
+
+WebUI.click(findTestObject('Accounts/CreateButton'))
+
+WebUI.click(findTestObject('Accounts/ClickCreateAccount'))
+
+WebUI.setText(findTestObject('Accounts/InputUserOrEmail'), GlobalVariable.userEmail)
+
+WebUI.setText(findTestObject('Accounts/InputPassword'), GlobalVariable.Pass)
+
+WebUI.setText(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/account_storage_overwiew'), '5')
+
+WebUI.click(findTestObject('Accounts/SaveButton'))
+
+WebUI.refresh()
+
+WebUI.delay(2)
+
+WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/Icon_account'))
+
+WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/lang_Log out'))
+
+WebUI.setText(findTestObject('Login/inputEmail'), GlobalVariable.userEmail)
+
+WebUI.click(findTestObject('Login/loginSubmit'))
+
+WebUI.setText(findTestObject('Login/inputPassword'), GlobalVariable.Pass)
+
+WebUI.click(findTestObject('Login/loginSubmit'))
+
+WebUI.click(findTestObject('Dashboard/lang_Folders'))
+
+WebUI.click(findTestObject('Folders/createFolderIcon'))
+
+WebUI.click(findTestObject('Folders/createFolder'))
+
+String topFolder = 'Top_lvl' + getTimestamp()
+
+WebUI.verifyElementClickable(findTestObject('Folders/resetInput'), FailureHandling.CONTINUE_ON_FAILURE)
+
+WebUI.setText(findTestObject('Folders/inputFolderName'), topFolder)
+
+WebUI.click(findTestObject('Folders/buttonOK'))
+
+WebUI.delay(2)
+
+WebUI.back()
+
+def btn = findFolder(topFolder)
+
+WebUI.executeJavaScript('arguments[0].click()', Arrays.asList(btn))
+
+assert topFolder != null
+
+WebUI.closeBrowser()
+
+WebElement findFolder(String topFolder) {
+    WebDriver driver = DriverFactory.getWebDriver()
+
+    return driver.findElement(By.xpath(('//*[contains(@data-search-keys, \'' + topFolder) + '\')]/td[1]/span'))
+}
+
+String generateRandomString(int length) {
+    String characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+    StringBuilder randomString = new StringBuilder()
+
+    Random random = new Random()
+
+    for (int i = 0; i < length; i++) {
+        randomString.append(characters.charAt(random.nextInt(characters.length())))
+    }
+    
+    return randomString.toString().toLowerCase()
+}
+
+String generateRandomEmail() {
+    return generateRandomString(8) + '@qa-automated-webtest.com'
+}
+
+String generateRandomPhoneNumber() {
+    Random random = new Random()
+
+    return String.format('(%03d) %03d-%04d', random.nextInt(1000), random.nextInt(1000), random.nextInt(10000))
+}
+
+String getTimestamp() {
+    Date todaysDate = new Date()
+
+    String formattedDate = todaysDate.format('_dd_MM_yyyy_hh_mm_ss')
+
+    return formattedDate
+}
+

--- a/Scripts/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder/Script1777630879360.groovy
+++ b/Scripts/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder/Script1777630879360.groovy
@@ -1,0 +1,133 @@
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import org.openqa.selenium.By as By
+import org.openqa.selenium.JavascriptExecutor as JavascriptExecutor
+import org.openqa.selenium.Keys as Keys
+import org.openqa.selenium.WebDriver as WebDriver
+import org.openqa.selenium.WebElement as WebElement
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.webui.driver.DriverFactory as DriverFactory
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import internal.GlobalVariable as GlobalVariable
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+import com.kms.katalon.core.cucumber.keyword.CucumberBuiltinKeywords as CucumberKW
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
+import static com.kms.katalon.core.testobject.ObjectRepository.findWindowsObject
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testobject.TestObject as TestObject
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+
+GlobalVariable.userEmail = generateRandomEmail().toLowerCase()
+
+WebUI.callTestCase(findTestCase('Login/Pretest - Admin Login'), [('variable') : ''], FailureHandling.OPTIONAL)
+
+WebUI.click(findTestObject('LeftNavigationIcons/account'))
+
+WebUI.click(findTestObject('Accounts/CreateButton'))
+
+WebUI.click(findTestObject('Accounts/ClickCreateAccount'))
+
+WebUI.setText(findTestObject('Accounts/InputUserOrEmail'), GlobalVariable.userEmail)
+
+WebUI.setText(findTestObject('Accounts/InputPassword'), GlobalVariable.Pass)
+
+WebUI.setText(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/account_storage_overwiew'), '5')
+
+WebUI.click(findTestObject('Accounts/SaveButton'))
+
+WebUI.refresh()
+
+WebUI.delay(2)
+
+WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/Icon_account'))
+
+WebUI.click(findTestObject('My_Account/Overview/Page_Accounts - PowerFolder/lang_Log out'))
+
+WebUI.setText(findTestObject('Login/inputEmail'), GlobalVariable.userEmail)
+
+WebUI.click(findTestObject('Login/loginSubmit'))
+
+WebUI.setText(findTestObject('Login/inputPassword'), GlobalVariable.Pass)
+
+WebUI.click(findTestObject('Login/loginSubmit'))
+
+WebUI.click(findTestObject('Dashboard/lang_Folders'))
+
+WebUI.click(findTestObject('Folders/createFolderIcon'))
+
+WebUI.click(findTestObject('Folders/createFolder'))
+
+String topFolder = 'Top_lvl' + getTimestamp()
+
+WebUI.verifyElementClickable(findTestObject('Folders/resetInput'), FailureHandling.CONTINUE_ON_FAILURE)
+
+WebUI.setText(findTestObject('Folders/inputFolderName'), topFolder)
+
+WebUI.click(findTestObject('Folders/buttonOK'))
+
+WebUI.delay(2)
+
+WebUI.verifyElementPresent(findTestObject('Folders/Page_Folders - PowerFolder/New subdirectory'), 5)
+
+WebUI.click(findTestObject('Folders/Page_Folders - PowerFolder/New subdirectory'))
+
+String subFolderName = "Sub"+ getTimestamp()
+
+WebUI.setText(findTestObject('Folders/inputFolderName'), subFolderName)
+
+WebUI.click(findTestObject('Folders/buttonOK'))
+
+WebUI.delay(2)
+
+WebUI.back()
+
+def btn = findFolder(subFolderName)
+
+WebUI.executeJavaScript('arguments[0].click()', Arrays.asList(btn))
+
+assert subFolderName != null
+
+WebUI.closeBrowser()
+
+WebElement findFolder(String topFolder) {
+	WebDriver driver = DriverFactory.getWebDriver()
+
+	return driver.findElement(By.xpath(('//*[contains(@data-search-keys, \'' + topFolder) + '\')]/td[1]/span'))
+}
+
+String generateRandomString(int length) {
+	String characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+	StringBuilder randomString = new StringBuilder()
+
+	Random random = new Random()
+
+	for (int i = 0; i < length; i++) {
+		randomString.append(characters.charAt(random.nextInt(characters.length())))
+	}
+	
+	return randomString.toString().toLowerCase()
+}
+
+String generateRandomEmail() {
+	return generateRandomString(8) + '@qa-automated-webtest.com'
+}
+
+String generateRandomPhoneNumber() {
+	Random random = new Random()
+
+	return String.format('(%03d) %03d-%04d', random.nextInt(1000), random.nextInt(1000), random.nextInt(10000))
+}
+
+String getTimestamp() {
+	Date todaysDate = new Date()
+
+	String formattedDate = todaysDate.format('_dd_MM_yyyy_hh_mm_ss')
+
+	return formattedDate
+}
+

--- a/Test Cases/Browser_Back_Button/.meta
+++ b/Test Cases/Browser_Back_Button/.meta
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FolderEntity>
+   <description>folder</description>
+   <name>Browser_Back_Button</name>
+   <tag></tag>
+   <folderType>TESTCASE</folderType>
+</FolderEntity>

--- a/Test Cases/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB01_Admin_DashboardToFolders_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>8e060d79-6e62-4dff-a24b-fd5737708247</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB02_Admin_DashboardToAccounts_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>c4973b0d-c935-4824-9eca-8e790bcbf332</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB03_Admin_DashboardToOrganizations_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>3e9c2d07-54f3-49f9-8d06-38c344b8145f</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB04_Admin_DashboardToServers_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>1546459d-d899-4e7d-891b-a8b59a8ce7a2</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB05_Admin_DashboardToStorage_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>21f76627-a455-4e7c-bd8d-ab92147531c3</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB06_Admin_DashboardToEmails_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>46219ebc-70e2-471b-8aa6-6fde566d27c9</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB07_Admin_DashboardToLogs_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>d59f9d13-5bde-45b0-811d-1ef2301eb1c2</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB08_Admin_DashboardToPreferences_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>a8ec2996-a16c-40f4-af79-29686c333802</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard.tc
+++ b/Test Cases/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB09_Admin_DashboardToNews_BackToDashboard</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>49fbf5cb-7bdb-4c49-ac6b-19f6875db1b2</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList.tc
+++ b/Test Cases/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB10_User_CreateFolder_BackToFolderList</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>38c64b9e-fb57-4640-9b59-b477ad4434f7</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder.tc
+++ b/Test Cases/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder.tc
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder</name>
+   <tag></tag>
+   <comment></comment>
+   <recordOption>OTHER</recordOption>
+   <testCaseGuid>8006b7c4-5c6e-4c03-8f7d-8e734fc6f10b</testCaseGuid>
+</TestCaseEntity>

--- a/Test Suites/AllTest.ts
+++ b/Test Suites/AllTest.ts
@@ -2930,4 +2930,81 @@
       <testCaseId>Test Cases/Links/TL57_Verify RW Link Creation When Upload Links Disabled</testCaseId>
       <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
    </testCaseLink>
+   <testCaseLink>
+      <guid>831df2d8-5d6e-4ad1-a2a8-f7b2aa3295f6</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>2e0a30ac-e184-4177-aeed-097d5c2d8c7b</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>614052b9-5056-4e5a-8d94-cd75cdf85ed6</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>102f991f-abc8-4f98-aae2-6d5d60e1819a</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>d4dfd4dc-f3e5-4767-8343-7402de64e673</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>8518568b-2c68-4e50-9e2c-82e6797b4ba8</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>70bbf207-66ce-4c66-8913-7388281ac0f4</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>4994cc51-36a6-4e47-87f1-6d0213d7e493</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>143818a5-c462-42c7-a546-7b0f8c60e0ae</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>94e031ad-25d8-492b-9245-39b7fd7300f8</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>4c1fe2aa-f81b-424d-a0dc-eec21c70c0bb</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
 </TestSuiteEntity>

--- a/Test Suites/Browser_Back_Button.groovy
+++ b/Test Suites/Browser_Back_Button.groovy
@@ -1,0 +1,66 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.checkpoint.CheckpointFactory as CheckpointFactory
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testcase.TestCaseFactory as TestCaseFactory
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testdata.TestDataFactory as TestDataFactory
+import com.kms.katalon.core.testobject.ObjectRepository as ObjectRepository
+import com.kms.katalon.core.testobject.TestObject as TestObject
+
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+
+import internal.GlobalVariable as GlobalVariable
+
+import com.kms.katalon.core.annotation.SetUp
+import com.kms.katalon.core.annotation.SetupTestCase
+import com.kms.katalon.core.annotation.TearDown
+import com.kms.katalon.core.annotation.TearDownTestCase
+
+/**
+ * Some methods below are samples for using SetUp/TearDown in a test suite.
+ */
+
+/**
+ * Setup test suite environment.
+ */
+@SetUp(skipped = true) // Please change skipped to be false to activate this method.
+def setUp() {
+	// Put your code here.
+}
+
+/**
+ * Clean test suites environment.
+ */
+@TearDown(skipped = true) // Please change skipped to be false to activate this method.
+def tearDown() {
+	// Put your code here.
+}
+
+/**
+ * Run before each test case starts.
+ */
+@SetupTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def setupTestCase() {
+	// Put your code here.
+}
+
+/**
+ * Run after each test case ends.
+ */
+@TearDownTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def tearDownTestCase() {
+	// Put your code here.
+}
+
+/**
+ * References:
+ * Groovy tutorial page: http://docs.groovy-lang.org/next/html/documentation/
+ */

--- a/Test Suites/Browser_Back_Button.ts
+++ b/Test Suites/Browser_Back_Button.ts
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestSuiteEntity>
+   <description></description>
+   <name>Browser_Back_Button</name>
+   <tag></tag>
+   <isRerun>false</isRerun>
+   <mailRecipient></mailRecipient>
+   <numberOfRerun>0</numberOfRerun>
+   <pageLoadTimeout>30</pageLoadTimeout>
+   <pageLoadTimeoutDefault>true</pageLoadTimeoutDefault>
+   <rerunFailedTestCasesOnly>false</rerunFailedTestCasesOnly>
+   <rerunImmediately>false</rerunImmediately>
+   <testSuiteGuid>2bff8b0a-c509-43d7-9a66-6f89403feba4</testSuiteGuid>
+   <testCaseLink>
+      <guid>4fd83361-ce02-446a-b3e5-2ff958bf3d27</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB01_Admin_DashboardToFolders_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>32afff5b-bd04-41fb-be5a-a1bd0a886250</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB02_Admin_DashboardToAccounts_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>6f247388-f257-441f-bea5-b7958e9d8d5a</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB03_Admin_DashboardToOrganizations_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>db431cc9-46af-4eac-95d5-e73e6f5e5fc0</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB04_Admin_DashboardToServers_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>7db497ed-e305-4f37-9eff-4300816bb03b</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB05_Admin_DashboardToStorage_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>6c309447-996b-4622-957e-cbc80f306856</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB06_Admin_DashboardToEmails_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>de9db0ba-05db-4659-b06c-9b74e30ac357</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB07_Admin_DashboardToLogs_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>41e4f9be-feda-4f82-94c9-1c1308839c91</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB08_Admin_DashboardToPreferences_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>34279f60-5343-4272-9ed3-7e9e3f84a99a</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB09_Admin_DashboardToNews_BackToDashboard</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>9b94a9e8-4c5f-4b30-971f-6f60082552fd</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB10_User_CreateFolder_BackToFolderList</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>31661394-a7ef-4a3d-a780-7eff494eb883</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Browser_Back_Button/BB11_User_CreateFolderAndSubfolder_BackToTopLevelFolder</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+</TestSuiteEntity>

--- a/settings/internal/com.kms.katalon.composer.testcase.properties
+++ b/settings/internal/com.kms.katalon.composer.testcase.properties
@@ -1,2 +1,2 @@
-#Tue Apr 28 12:32:00 WEST 2026
+#Fri May 01 13:15:02 WEST 2026
 testCaseTag=""


### PR DESCRIPTION
This branch features:

- a new set of testcases which use the browsers back-button to verify its function in the web-ui

This branch ran successfully on mimas with 27.2.101.